### PR TITLE
Handle slash scores in parse_feedback

### DIFF
--- a/essay_grading.py
+++ b/essay_grading.py
@@ -5,6 +5,7 @@ from openai import OpenAI
 client = OpenAI(api_key='') #INSERT KEY INSODE HE QUOTES IN THE BRACKET
 import os
 from docx import Document
+import re
 
 # Function to extract text from a .docx file
 def extract_text_from_docx(file):
@@ -32,10 +33,17 @@ def parse_feedback(feedback):
         for key in scores.keys():
             if key in line:
                 score = line.split(':')[-1].strip()
-                scores[key] = score
+                match = re.search(r'(\d+)\s*/', score)
+                if match:
+                    numeric_score = int(match.group(1))
+                else:
+                    try:
+                        numeric_score = int(score)
+                    except ValueError:
+                        numeric_score = None
+                scores[key] = numeric_score
 
-    # Assume that the last numerical value mentioned is the total score
-    total_score = sum([int(score) for score in scores.values() if score])
+    total_score = sum([scores[k] for k in scores if k != 'Total Score' and isinstance(scores[k], int)])
     scores['Total Score'] = total_score
     return scores
 
@@ -82,8 +90,8 @@ def export_to_csv(data):
 def main():
     st.title("olukoAI Essay Grader by Effico")
 
-    # Predefined rubric for grading
-    rubric = """
+    # Default grading instructions and rubric
+    rubric_default = """
     INSTRUCTIONS FOR GRADING
     1. Content and Relevance: 25
     2. Clarity and Organisation: 20
@@ -92,9 +100,13 @@ def main():
     5. Writing Style and Language: 15
     6. Conclusion: 5
     7. Overall Impression: 10
-    
+
     Total: 110
     """
+
+    rubric = st.text_area(
+        "Enter grading instructions and rubric", rubric_default, height=200
+    )
 
     # State to store results
     if 'results' not in st.session_state:
@@ -148,6 +160,10 @@ def main():
 
                 # Parse feedback into rubric components
                 parsed_scores = parse_feedback(result)
+
+                # Display the parsed scores on the UI
+                st.write("Scores:")
+                st.write(parsed_scores)
 
                 # Store results in session state
                 st.session_state.results.append({


### PR DESCRIPTION
## Summary
- parse numeric score preceding `/` in rubric feedback
- calculate total score by summing all subtotals
- allow grading instructions and rubric customization in the UI

## Testing
- `python -m py_compile essay_grading.py`
- `python - <<'PY'
from essay_grading import parse_feedback
sample = "Content Relevance: 25/25\nClarity and Organisation: 18/20\nOriginality and Creativity: 12/15\nResearch and Evidence: 20/20\nWriting Style and Language: 14/15\nConclusion: 5/5\nOverall Impression: 9/10\nTotal Score: 103/110"
print(parse_feedback(sample))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68419dec03e8832e9f920b031f84ad0a